### PR TITLE
Add all dev dependencies with a single command 🔩

### DIFF
--- a/scripts/addDevDependencies.js
+++ b/scripts/addDevDependencies.js
@@ -26,17 +26,20 @@ function installDevDependencies() {
 
     const devDependenciesJsonPath = path.resolve('devDependencies.json');
     const devDependencies = JSON.parse(fs.readFileSync(devDependenciesJsonPath));
+    let depsToInstall = [];
 
     for (const depName in devDependencies) {
         const depVersion = devDependencies[depName];
         const depToInstall = `${depName}@${depVersion}`;
-        console.log(`Adding ${depToInstall}...`);
+        depsToInstall.push(depToInstall);
+    }
 
-        if (getYarnVersionIfAvailable()) {
-            execSync(`yarn add ${depToInstall} -D`, {stdio: 'inherit'});
-        } else {
-            execSync(`npm install ${depToInstall} --save`);
-        }
+    depsToInstall = depsToInstall.join(' ');
+    console.log(`Adding ${depsToInstall}...`);
+    if (getYarnVersionIfAvailable()) {
+        execSync(`yarn add ${depsToInstall} -D`, {stdio: 'inherit'});
+    } else {
+        execSync(`npm install ${depsToInstall} --save`);
     }
     console.log("Deleting devDependencies.json...");
     execSync(`rm  ${devDependenciesJsonPath}`);


### PR DESCRIPTION
Run a single `yarn` or `npm` command to install the dev dependencies, instead of many. This is likely to be much quicker (with Yarn at least), and also more pleasant to watch.