### PR TITLE
Load Reactnative-web components

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -74,7 +74,7 @@ module.exports = {
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:
     // https://github.com/facebookincubator/create-react-app/issues/290
-    extensions: ['.js', '.json', '.jsx', ''],
+    extensions: ['.web.js', '.js', '.json', '.web.jsx', '.jsx', ''],
     alias: {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/


### PR DESCRIPTION
Allow to load components that have special components for ReactNative-web under `*.web.js` and `*.web.jsx` extensions. This should be done too on `webpack.config.prod.js` file, or better than that, make this file to inherit and overrride values from there as it's done for example in Django.