### PR TITLE
chore(rnw): update from `0.1.13` to `0.6.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ node scripts/additionalDependencies.js
 "web": "node scripts/start.js",
 "build": "node scripts/build.js"
 ```
-- react-native-web currently (20th of July, 2017) supports React/ReactDOM 15.4, 15.5, or 15.6, so make sure you do not upgrade if you want support for web.
 - make sure that the version of react-native-windows is same as your react-native version, if you are targeting windows support.
 
 ---

--- a/templates/re-base/dependencies.json
+++ b/templates/re-base/dependencies.json
@@ -1,5 +1,5 @@
 {
   "react": "^16.2.0",
   "react-dom": "^16.2.0",
-  "react-native-web": "0.1.13"
+  "react-native-web": "0.6.0"
 }

--- a/templates/re-dux/dependencies.json
+++ b/templates/re-dux/dependencies.json
@@ -1,7 +1,7 @@
 {
   "react": "^16.2.0",
   "react-dom": "^16.2.0",
-  "react-native-web": "0.1.13",
+  "react-native-web": "0.6.0",
   "react-redux": "5.0.6",
   "redux": "3.7.2",
   "redux-thunk": "2.2.0"

--- a/templates/re-route/dependencies.json
+++ b/templates/re-route/dependencies.json
@@ -1,7 +1,7 @@
 {
   "react": "^16.2.0",
   "react-dom": "^16.2.0",
-  "react-native-web": "0.1.13",
+  "react-native-web": "0.6.0",
   "react-router": "4.2.0",
   "react-router-dom": "4.2.2",
   "react-router-native": "4.2.0",

--- a/templates/re-start/dependencies.json
+++ b/templates/re-start/dependencies.json
@@ -1,7 +1,7 @@
 {
   "react": "^16.2.0",
   "react-dom": "^16.2.0",
-  "react-native-web": "0.1.13",
+  "react-native-web": "0.6.0",
   "react-redux": "5.0.6",
   "react-router": "4.2.0",
   "react-router-dom": "4.2.2",


### PR DESCRIPTION
## Why

`react-native-web` version is too old. #61

## What

update to [0.6.0](https://github.com/necolas/react-native-web/releases/tag/0.6.0)

## And

Close #61